### PR TITLE
Fix about FAB Icon 

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ export default class FAB extends Component {
             style={styles.addButtonInnerView}
             buttonColor={buttonColor}
           >
-            <Animated.Text
+            <Animated.View
               style={{
                 transform: [
                   { scaleX: translateValue },
@@ -190,7 +190,7 @@ export default class FAB extends Component {
                 fontSize: 24,
                 color: iconTextColor,
               } })}
-            </Animated.Text>
+            </Animated.View>
           </Touchable>
         </Animated.View>
       </Animated.View>


### PR DESCRIPTION
If I add icon in FAB props(iconTextComponent), it occur error.

`Invariant Violation: Nesting of <View> within <Text> is not currently supported.`

The props is 'Animated.Text'. It's the problem.

So I replace `Animated.Text` with `Animated.View'.